### PR TITLE
feat: filter stats to show only today's data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 
 # Build output
 dist/
+
+# Kiro IDE
+.kiro/

--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -1,4 +1,4 @@
-import { getSessions } from "../services/stateManager";
+import { getSessions, getTodaySessions } from "../services/stateManager";
 import {
   getCurrentTimeSpent,
   stopTrackingTab,
@@ -8,6 +8,7 @@ import {
 // TODO: P2 Better action types
 export const CURRENT_TIME_SPENT_REQUESTED = "currentTimeSpentRequested";
 export const SESSIONS_REQUESTED = "sessionsRequested";
+export const TODAY_SESSIONS_REQUESTED = "todaySessionsRequested";
 export const TRACKING_STOPPED = "trackingStopped";
 export const TRACKING_STARTED = "trackingStarted";
 
@@ -29,6 +30,18 @@ export const handleMessage = (
     getSessions().then((sessions) => {
       sendResponse({ sessions });
     });
+    return true;
+  }
+
+  if (request.action === TODAY_SESSIONS_REQUESTED) {
+    getTodaySessions()
+      .then((sessions) => {
+        sendResponse({ sessions });
+      })
+      .catch((error) => {
+        console.error("Error getting today sessions:", error);
+        sendResponse({ error: error.message, sessions: [] });
+      });
     return true;
   }
 

--- a/src/background/services/stateManager.ts
+++ b/src/background/services/stateManager.ts
@@ -1,6 +1,7 @@
 import { TimeSession } from "../../types/timeTracking";
 import { ActiveSession } from "./activeSession";
 import { TimeTrackingState } from "./timeTrackingState";
+import { isToday } from "../../utils/isToday";
 
 export const getActiveSession = async (tabId: number) => {
   const state = await getTimeTrackingState();
@@ -27,7 +28,7 @@ export const removeActiveSession = async (tabId: number) => {
 
   // Clear current active tab if it was the removed tab
   if (state.currentActiveTabId === tabId) {
-    delete state.currentActiveTabId;
+    state.currentActiveTabId = undefined;
   }
 
   await setTimeTrackingState(state);
@@ -36,7 +37,7 @@ export const removeActiveSession = async (tabId: number) => {
 export const setCurrentActiveTabId = async (tabId: number | undefined) => {
   const state = await getTimeTrackingState();
   if (tabId === undefined) {
-    delete state.currentActiveTabId;
+    state.currentActiveTabId = undefined;
   } else {
     state.currentActiveTabId = tabId;
   }
@@ -67,6 +68,16 @@ export const saveSession = async (session: TimeSession) => {
     await chrome.storage.local.set({ sessions });
   } catch (error) {
     console.error("Failed to save session:", error);
+  }
+};
+
+export const getTodaySessions = async (): Promise<TimeSession[]> => {
+  try {
+    const allSessions = await getSessions();
+    return allSessions.filter((session) => isToday(session.startTime));
+  } catch (error) {
+    console.error("Error filtering today sessions:", error);
+    throw new Error("Failed to filter today sessions");
   }
 };
 

--- a/src/newtab/Sessions/index.tsx
+++ b/src/newtab/Sessions/index.tsx
@@ -4,15 +4,33 @@ import TopSites from "./TopSites";
 import RecentSessions from "./RecentSessions";
 import { Stats } from "./Stats";
 
+// TODO: P1 Extract the wrapping component
 export const Sessions = () => {
-  const { sessions, isLoading } = useSessions();
+  const { sessions, isLoading, error, refetch } = useSessions();
   const { domainStats } = useStatsData(sessions);
 
   if (isLoading) {
     return (
       <div className={containerClasses}>
-        <h2 className="headerClasses">Time Tracking</h2>
+        <h2 className={headerClasses}>Time Tracking</h2>
         <div className="text-white/60">Loading sessions...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={containerClasses}>
+        <h2 className={headerClasses}>Time Tracking</h2>
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="text-red-400">{error}</div>
+          <button
+            onClick={refetch}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/utils/isToday.ts
+++ b/src/utils/isToday.ts
@@ -1,0 +1,11 @@
+export const isToday = (timestamp: number): boolean => {
+  const today = new Date();
+  const timestampDate = new Date(timestamp);
+
+  // Compare year, month, and day in local timezone
+  return (
+    today.getFullYear() === timestampDate.getFullYear() &&
+    today.getMonth() === timestampDate.getMonth() &&
+    today.getDate() === timestampDate.getDate()
+  );
+};


### PR DESCRIPTION
- Add isToday utility function for timezone-aware date filtering
- Create getTodaySessions background service function
- Add TODAY_SESSIONS_REQUESTED message handler
- Update useSessions hook to request today's data with error handling
- Update Sessions component to display error states and retry functionality
- Improve performance by filtering at data source instead of UI layer

Resolves today-stats-filter spec requirements