### PR TITLE
Handle browser closure and cleanup stale sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules/
 # Build output
 dist/
 
-# Kiro IDE
-.kiro/
+.claude/plans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+The project uses pnpm as the package manager. Key commands:
+
+- `pnpm run build` - Build the extension for production
+- `pnpm run dev` - Build and watch for changes (development mode)
+- `pnpm run clean` - Clean the dist folder
+- `pnpm run test` - Run tests in watch mode
+- `pnpm run test:run` - Run tests once and exit
+
+## Architecture Overview
+
+This is a Chrome Extension (Manifest V3) built with TypeScript, React, and Vite. It implements a time tracking system that monitors browsing sessions across different domains.
+
+### Core Components
+
+**Background Service Worker** (`src/background/`)
+- Entry point: `src/background/index.ts`
+- Handles Chrome extension lifecycle events (installation, tab changes, messages)
+- Manages time tracking logic through modular handlers:
+  - `handlers/installation.ts` - Extension installation setup
+  - `handlers/messages.ts` - Inter-component communication
+  - `handlers/tabs.ts` - Tab lifecycle management (creation, updates, removal, activation)
+  - `services/timeTracking.ts` - Core time tracking business logic
+  - `services/stateManager.ts` - Chrome storage state management
+  - `services/activeSession.ts` - Active session data models
+
+**User Interfaces**
+- **New Tab Page** (`src/newtab/`) - Replaces Chrome's default new tab with time tracking dashboard
+  - Shows current time, recent sessions, stats, and top sites
+  - Components: Clock, Sessions (with RecentSessions, Stats, TopSites subcomponents)
+- **Popup** (`src/popup/`) - Extension popup showing current tab tracking status
+  - Displays time spent on current page and tracking status
+
+**Content Scripts**
+- `src/content.ts` - Runs on all pages for potential future functionality
+
+### Data Models
+
+Key TypeScript interfaces in `src/types/timeTracking.ts`:
+- `TimeSession` - Completed browsing session with duration
+- `ActiveSession` - Currently active browsing session
+- `TimeTrackingState` - Overall state including active sessions and current tab
+
+### Utilities
+
+- `src/utils/domainUtils.ts` - Domain extraction and URL parsing (has comprehensive unit tests)
+- `src/utils/timeFormatters.ts` - Time formatting utilities
+- `src/utils/isTrackableUrl.ts` - Determines if URLs should be tracked (excludes chrome:// pages)
+- `src/utils/getCurrentTime.ts` - Consistent timestamp generation
+- `src/utils/isToday.ts` - Date comparison utilities
+
+### Time Tracking Logic
+
+The extension tracks time spent on trackable URLs by:
+1. Starting sessions when tabs are created/activated with trackable URLs
+2. Stopping sessions when tabs are closed/deactivated
+3. Switching tracking between tabs based on user focus
+4. Updating sessions when URLs change within the same tab
+5. Storing completed sessions in Chrome storage for dashboard display
+
+### Build System
+
+- **Vite** with TypeScript and React support
+- **@crxjs/vite-plugin** for Chrome extension packaging
+- **Tailwind CSS** with the new v4 Vite plugin for styling
+- **Vitest** for unit testing
+
+### Storage
+
+Uses Chrome's storage API to persist:
+- Active sessions across browser restarts
+- Completed time tracking sessions
+- Current active tab state
+
+### Testing
+
+- Unit tests are configured with Vitest
+- Existing tests for domain utilities demonstrate testing patterns
+- Tests run in Node.js environment with global test APIs enabled
+- Never attribute Claude Code in commit messages

--- a/src/background/handlers/installation.ts
+++ b/src/background/handlers/installation.ts
@@ -1,9 +1,0 @@
-import { getSessions } from "../services/stateManager";
-
-export const handleInstallation = async () => {
-  const sessions = await getSessions();
-  if (sessions.length === 0) {
-    // This is a fresh install, no need to do anything as getSessions returns empty array
-    console.log("Extension installed - initialized with empty sessions");
-  }
-};

--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -1,7 +1,5 @@
 import { getSessions, getTodaySessions } from "../services/stateManager";
-import {
-  getCurrentTimeSpent,
-} from "../services/timeTracking";
+import { getCurrentTimeSpent } from "../services/timeTracking";
 
 // TODO: P2 Better action types
 export const CURRENT_TIME_SPENT_REQUESTED = "currentTimeSpentRequested";
@@ -13,8 +11,6 @@ export const handleMessage = (
   _sender: chrome.runtime.MessageSender,
   sendResponse: (response?: unknown) => void
 ) => {
-  console.log("Message received in background:", request);
-
   if (request.action === CURRENT_TIME_SPENT_REQUESTED) {
     getCurrentTimeSpent().then((timeSpent) => {
       sendResponse({ timeSpent });

--- a/src/background/handlers/startup.ts
+++ b/src/background/handlers/startup.ts
@@ -1,0 +1,6 @@
+import { cleanupStaleSessions } from "../services/timeTracking";
+
+export const handleStartup = async () => {
+  // Clean up any stale sessions from previous run (crash/force-quit)
+  await cleanupStaleSessions();
+};

--- a/src/background/handlers/tabs.ts
+++ b/src/background/handlers/tabs.ts
@@ -34,7 +34,12 @@ export const handleTabUpdate = async (
   }
 
   // Only act when page is fully loaded, has a URL, and no URL change was processed
-  if (changeInfo.status === "complete" && tab.active && tab.url && !changeInfo.url) {
+  if (
+    changeInfo.status === "complete" &&
+    tab.active &&
+    tab.url &&
+    !changeInfo.url
+  ) {
     // Check if we already have an active session to prevent duplicates
     const existingSession = await getActiveSession(tabId);
 

--- a/src/background/handlers/windows.ts
+++ b/src/background/handlers/windows.ts
@@ -1,0 +1,15 @@
+import { stopAllActiveSessions } from "../services/timeTracking";
+
+export const handleWindowRemoved = async (windowId: number) => {
+  console.log(`Window ${windowId} removed, checking if any windows remain`);
+
+  // Check if any windows remain
+  const windows = await chrome.windows.getAll();
+
+  if (windows.length === 0) {
+    console.log("No windows remain, stopping all active sessions");
+    await stopAllActiveSessions();
+  } else {
+    console.log(`${windows.length} window(s) still open`);
+  }
+};

--- a/src/background/handlers/windows.ts
+++ b/src/background/handlers/windows.ts
@@ -3,13 +3,15 @@ import { stopAllActiveSessions } from "../services/timeTracking";
 export const handleWindowRemoved = async (windowId: number) => {
   console.log(`Window ${windowId} removed, checking if any windows remain`);
 
-  // Check if any windows remain
-  const windows = await chrome.windows.getAll();
+  // Check if any normal browser windows remain (exclude devtools, popups, panels, etc.)
+  const windows = await chrome.windows.getAll({
+    windowTypes: ["normal"],
+  });
 
   if (windows.length === 0) {
-    console.log("No windows remain, stopping all active sessions");
+    console.log("No normal windows remain, stopping all active sessions");
     await stopAllActiveSessions();
   } else {
-    console.log(`${windows.length} window(s) still open`);
+    console.log(`${windows.length} normal window(s) still open`);
   }
 };

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,13 +1,17 @@
-import { handleInstallation } from "./handlers/installation";
+import { handleStartup } from "./handlers/startup";
 import { handleMessage } from "./handlers/messages";
 import {
   handleTabUpdate,
   handleTabRemoval,
   handleTabActivation,
 } from "./handlers/tabs";
+import { handleWindowRemoved } from "./handlers/windows";
 
-// Listen for extension installation
-chrome.runtime.onInstalled.addListener(handleInstallation);
+// Listen for extension startup (both install and browser restart)
+chrome.runtime.onStartup.addListener(handleStartup);
+
+// Also listen for installation to handle fresh installs
+chrome.runtime.onInstalled.addListener(handleStartup);
 
 // Listen for messages from content scripts or popup
 chrome.runtime.onMessage.addListener(handleMessage);
@@ -20,5 +24,8 @@ chrome.tabs.onRemoved.addListener(handleTabRemoval);
 
 // Listen for tab activation (when user switches tabs)
 chrome.tabs.onActivated.addListener(handleTabActivation);
+
+// Listen for window removal (browser close)
+chrome.windows.onRemoved.addListener(handleWindowRemoved);
 
 export {};

--- a/src/background/services/stateManager.ts
+++ b/src/background/services/stateManager.ts
@@ -14,6 +14,11 @@ export const getCurrentActiveTabId = async () => {
   return state.currentActiveTabId;
 };
 
+export const getAllActiveSessions = async () => {
+  const state = await getTimeTrackingState();
+  return state.activeSessions;
+};
+
 export const setActiveSession = async (
   tabId: number,
   session: ActiveSession

--- a/src/background/services/timeTracking.ts
+++ b/src/background/services/timeTracking.ts
@@ -193,7 +193,9 @@ export const stopAllActiveSessions = async () => {
 
   console.log(`Stopping ${tabIds.length} active sessions`);
 
-  await Promise.all(tabIds.map((tabId) => stopTrackingTab(tabId)));
+  for (const tabId of tabIds) {
+    await stopTrackingTab(tabId);
+  }
 };
 
 export const cleanupStaleSessions = async () => {
@@ -207,31 +209,29 @@ export const cleanupStaleSessions = async () => {
 
   console.log(`Cleaning up ${tabIds.length} stale sessions from previous run`);
 
-  await Promise.all(
-    tabIds.map(async (tabId) => {
-      const activeSession = activeSessions[tabId];
-      if (!activeSession) {
-        return;
-      }
+  for (const tabId of tabIds) {
+    const activeSession = activeSessions[tabId];
+    if (!activeSession) {
+      continue;
+    }
 
-      // Create a zero-duration session (endTime = startTime)
-      const staleSession: TimeSession = {
-        id: crypto.randomUUID(),
-        url: activeSession.url,
-        title: activeSession.title,
-        domain: activeSession.domain,
-        startTime: activeSession.startTime,
-        endTime: activeSession.startTime,
-        duration: 0,
-        tabId,
-      };
+    // Create a zero-duration session (endTime = startTime)
+    const staleSession: TimeSession = {
+      id: crypto.randomUUID(),
+      url: activeSession.url,
+      title: activeSession.title,
+      domain: activeSession.domain,
+      startTime: activeSession.startTime,
+      endTime: activeSession.startTime,
+      duration: 0,
+      tabId,
+    };
 
-      await saveSession(staleSession);
-      await removeActiveSession(tabId);
+    await saveSession(staleSession);
+    await removeActiveSession(tabId);
 
-      console.log(
-        `Cleaned up stale session for tab ${tabId}: ${activeSession.domain}`
-      );
-    })
-  );
+    console.log(
+      `Cleaned up stale session for tab ${tabId}: ${activeSession.domain}`
+    );
+  }
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chrome Extension TypeScript",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "A Chrome extension built with TypeScript and Vite",
   "permissions": ["activeTab", "storage", "tabs"],
   "background": {

--- a/src/newtab/Version/index.tsx
+++ b/src/newtab/Version/index.tsx
@@ -1,7 +1,7 @@
 export const Version = () => {
   return (
     <div className="absolute bottom-2 left-1/2 transform -translate-x-1/2 text-xs text-slate-400 opacity-20">
-      v1.1.0
+      v1.1.2
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Implemented proper session management for browser close events
- Stop all active sessions when browser closes normally via `chrome.windows.onRemoved`
- Clean up stale sessions on startup (from crashes/force-quits) with zero duration
- Renamed `installation.ts` → `startup.ts` for clarity
- Fixed race condition by removing active session before saving

## Changes
- Added `stopAllActiveSessions()` function to stop all active sessions
- Added `cleanupStaleSessions()` function to handle stale sessions from previous run
- Created `windows.ts` handler for window removal events
- Updated event listeners to use `onStartup` and `onInstalled`
- Reordered session removal before save to prevent double-stop race conditions

## Test plan
- [ ] Close individual tabs - verify sessions are stopped once
- [ ] Close browser normally - verify all active sessions are properly stopped
- [ ] Force-quit browser - verify stale sessions are cleaned up on restart with zero duration
- [ ] Fresh install - verify no errors on first startup